### PR TITLE
Fix settings verification

### DIFF
--- a/mosparo_django/__init__.py
+++ b/mosparo_django/__init__.py
@@ -19,4 +19,4 @@ for setting, type in settings_types.items():
         raise ImproperlyConfigured('Setting "%s" is not defined.' % setting)
 
     if hasattr(settings, setting) and not isinstance(getattr(settings, setting), type):
-        raise ImproperlyConfigured('Type of Setting "%s" is not correct. Should be "%s".' % setting, type)
+        raise ImproperlyConfigured('Type of Setting "%s" is not correct. Should be "%s".' % (setting, type))


### PR DESCRIPTION
Hello!

Sometimes when your `__init__.py` tries to raise an `ImproperlyConfigured` exception, it leads to a `TypeError`, here on my pet project: 

![Unhelpful message](https://github.com/user-attachments/assets/e9c5fcfb-bfa7-45f7-86d6-ee749b565274)

It seems to be an issue of operators' precedence, I propose to explicitly use a tuple here in order to provide an explicit error message to your users. :)
